### PR TITLE
add missing creditor reference line

### DIFF
--- a/src/QrPayment.php
+++ b/src/QrPayment.php
@@ -50,6 +50,11 @@ final class QrPayment implements QrPaymentInterface
     /**
      * @var string
      */
+    private $creditorReference = '';
+
+    /**
+     * @var string
+     */
     private $remittanceText = '';
 
     /**
@@ -236,6 +241,30 @@ final class QrPayment implements QrPaymentInterface
     /**
      * @return string
      */
+    public function getCreditorReference(): string
+    {
+        return $this->creditorReference;
+    }
+
+    /**
+     * @param string $creditorReference
+     *
+     * @return QrPayment
+     */
+    public function setCreditorReference(string $creditorReference): QrPayment
+    {
+        $this->checkLength($creditorReference, 35);
+        if (!empty($this->remittanceText)) {
+            throw new \InvalidArgumentException('Creditor reference must be empty if remittance text is set');
+        }
+        $this->creditorReference = $creditorReference;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
     public function getRemittanceText(): string
     {
         return $this->remittanceText;
@@ -249,6 +278,9 @@ final class QrPayment implements QrPaymentInterface
     public function setRemittanceText(string $remittanceText): QrPayment
     {
         $this->checkLength($remittanceText, 140);
+        if (!empty($this->creditorReference)) {
+            throw new \InvalidArgumentException('Remittance text must be empty if creditor reference is set');
+        }
         $this->remittanceText = $remittanceText;
 
         return $this;
@@ -346,6 +378,7 @@ final class QrPayment implements QrPaymentInterface
         $result[] = $this->getIban()->asString();
         $result[] = $amount ? $this->getCurrency() . $amount : '';
         $result[] = $this->getPurpose();
+        $result[] = $this->getCreditorReference();
         $result[] = $this->getRemittanceText();
         $result[] = $this->getInformation();
         foreach ($this->configuration->getCustomData() as $customDatum) {

--- a/tests/Config/AbstractConfigurationTest.php
+++ b/tests/Config/AbstractConfigurationTest.php
@@ -51,7 +51,7 @@ class AbstractConfigurationTest extends TestCase
     {
         // test default
         $instance = $this->getInstance();
-        self::assertCount(11, $this->getLines($instance));
+        self::assertCount(12, $this->getLines($instance));
 
         $config = new class extends AbstractConfiguration {
             public function getCustomData(): iterable
@@ -61,9 +61,9 @@ class AbstractConfigurationTest extends TestCase
             }
         };
         $instance = $this->getInstance($config);
-        self::assertCount(13, $this->getLines($instance));
-        self::assertEquals('A', $this->getLine($instance, 11));
-        self::assertEquals('B', $this->getLine($instance, 12));
+        self::assertCount(14, $this->getLines($instance));
+        self::assertEquals('A', $this->getLine($instance, 12));
+        self::assertEquals('B', $this->getLine($instance, 13));
     }
 
     public function testGetAmountPrecision()
@@ -164,7 +164,7 @@ class AbstractConfigurationTest extends TestCase
         $instance = $this->getInstance($config);
         $instance->setDueDate(new DateTimeImmutable('2025-01-01 12:00:00'));
         self::assertEquals('2025-01-01 12:00:00', $instance->getDueDate()->format('Y-m-d H:i:s'));
-        self::assertEquals('20250101', $this->getLine($instance, 11));
+        self::assertEquals('20250101', $this->getLine($instance, 12));
     }
 
     private function getInstance(AbstractConfiguration $configuration = null): QrPayment


### PR DESCRIPTION
specification requires both creditor reference and remittance text lines to be present; see #43 for details